### PR TITLE
UPSTREAM: <carry>: Fix entrypoint in Dockerfile.openshift

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -8,4 +8,4 @@ RUN yum update -y && \
     yum install --setopt=tsflags=nodocs -y ca-certificates && \
     yum clean all && rm -rf /var/cache/yum/*
 COPY --from=builder /go/src/github.com/IBM/vpc-node-label-updater/vpc-node-label-updater  /usr/bin/vpc-node-label-updater
-ENTRYPOINT ["/usr/bin/vpc-node-lable-updater"]
+ENTRYPOINT ["/usr/bin/vpc-node-label-updater"]


### PR DESCRIPTION
This typo was causing a failure during pod init:
```
  Warning  Failed   15s               kubelet  Error: container create failed: time="2021-12-14T00:05:47Z" level=error msg="container_linux.go:380: starting container process caused: exec: \"/usr/bin/vpc-node-lable-updater\": stat /usr/bin/vpc-node-lable-updater: no such file or directory"
```
/cc @openshift/storage 