### PR TITLE
Rebase: ibm-vpc-node-label-updater v4.1.6

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,4 +1,4 @@
-FROM golang:1.16.10
+FROM golang:1.16.15
 
 WORKDIR /go/src/github.com/IBM/vpc-node-label-updater
 ADD . /go/src/github.com/IBM/vpc-node-label-updater

--- a/pkg/nodeupdater/node_label.go
+++ b/pkg/nodeupdater/node_label.go
@@ -44,7 +44,7 @@ func (c *VpcNodeLabelUpdater) UpdateNodeLabel(ctx context.Context, workerNodeNam
 		return false, err
 	}
 
-	c.Node.ObjectMeta.Labels[workerIDLabelKey] = nodeinfo.InstanceID
+	c.Node.ObjectMeta.Labels[instanceIDLabelKey] = nodeinfo.InstanceID
 	c.Node.ObjectMeta.Labels[failureRegionLabelKey] = nodeinfo.Region
 	c.Node.ObjectMeta.Labels[failureZoneLabelKey] = nodeinfo.Zone
 	c.Node.ObjectMeta.Labels[topologyRegionLabelKey] = nodeinfo.Region

--- a/pkg/nodeupdater/node_label.go
+++ b/pkg/nodeupdater/node_label.go
@@ -44,6 +44,9 @@ func (c *VpcNodeLabelUpdater) UpdateNodeLabel(ctx context.Context, workerNodeNam
 		return false, err
 	}
 
+	// Are adding both worker-id and instance-id label to satisfy all environements.
+	// TODO: remove worker-id label after its dependence is removed.
+	c.Node.ObjectMeta.Labels[workerIDLabelKey] = nodeinfo.InstanceID
 	c.Node.ObjectMeta.Labels[instanceIDLabelKey] = nodeinfo.InstanceID
 	c.Node.ObjectMeta.Labels[failureRegionLabelKey] = nodeinfo.Region
 	c.Node.ObjectMeta.Labels[failureZoneLabelKey] = nodeinfo.Zone

--- a/pkg/nodeupdater/utils.go
+++ b/pkg/nodeupdater/utils.go
@@ -38,6 +38,7 @@ import (
 )
 
 const (
+	workerIDLabelKey       = "ibm-cloud.kubernetes.io/worker-id"
 	instanceIDLabelKey     = "ibm-cloud.kubernetes.io/vpc-instance-id"
 	failureRegionLabelKey  = "failure-domain.beta.kubernetes.io/region"
 	failureZoneLabelKey    = "failure-domain.beta.kubernetes.io/zone"

--- a/pkg/nodeupdater/utils_test.go
+++ b/pkg/nodeupdater/utils_test.go
@@ -109,7 +109,7 @@ func TestGetAccessToken(t *testing.T) {
 	for _, tc := range testCases {
 		t.Logf("Test case: %s", tc.name)
 		_, err := tc.secretConfig.GetAccessToken(logger)
-		if err != nil {
+		if err != nil && tc.expErr != nil {
 			if err.Error() != tc.expErr.Error() && !strings.Contains(err.Error(), tc.expErr.Error()) {
 				t.Fatalf("Expected error code: %v, got: %v. err : %v", tc.expErr, err, err)
 			}
@@ -199,6 +199,7 @@ func TestCheckIfRequiredLabelsPresent(t *testing.T) {
 	exp := CheckIfRequiredLabelsPresent(labelMap)
 	assert.Equal(t, exp, false)
 	labelMap[vpcBlockLabelKey] = "true"
+	labelMap[instanceIDLabelKey] = "true"
 	ex := CheckIfRequiredLabelsPresent(labelMap)
 	assert.Equal(t, ex, true)
 }

--- a/pkg/nodeupdater/utils_test.go
+++ b/pkg/nodeupdater/utils_test.go
@@ -461,3 +461,40 @@ func TestGetNodeInfo(t *testing.T) {
 		continue
 	}
 }
+
+func TestCorrectEndpointURL(t *testing.T) {
+	testCases := []struct {
+		name      string
+		url       string
+		returnURL string
+	}{
+		{
+			name:      "URL of http form",
+			url:       "http://example.com",
+			returnURL: "https://example.com",
+		},
+		{
+			name:      "URL of https form",
+			url:       "https://example.com",
+			returnURL: "https://example.com",
+		},
+		{
+			name:      "Incorrect URL",
+			url:       "xyz.com",
+			returnURL: "xyz.com",
+		},
+		{
+			name:      "Incorrect URL",
+			url:       "httpd://xyz.com",
+			returnURL: "httpd://xyz.com",
+		},
+	}
+	logger, teardown := GetTestLogger(t)
+	defer teardown()
+
+	for _, tc := range testCases {
+		t.Logf("Test case: %s", tc.name)
+		url := getEndpointURL(tc.url, logger)
+		assert.Equal(t, tc.returnURL, url)
+	}
+}


### PR DESCRIPTION
This rebase is required by https://github.com/openshift/ibm-vpc-block-csi-driver/pull/14

- Change logic for reading config from secret
- Add vpc-id label
- Fix UT issues
- Add worker id label

Upstream comparison:
https://github.com/IBM/vpc-node-label-updater/compare/v4.1.6...dobsonj:rebase-v4.1.4

/cc @openshift/storage
